### PR TITLE
Make CSS rule specific to course format FNTab

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -305,7 +305,7 @@ tr.oddrow {
     padding-top:0;
 }
 
-table {
+#page-course-view-fntabs table {
     font-size:100% !important;
 }
 /*#page-course-view-fntabs #page-content .region-content {


### PR DESCRIPTION
Globally setting TABLE html element font-size to 100% with !important causes font issues on various parts of our Moodle system.

Making it specific to FNTab fixes this issue.

Actually, any CSS rule that is not specific to FNTab is affecting other parts of the system, since Moodle aggregates all CSS files from all the modules.

Please see if you can accept this change.

Nadav :-)
